### PR TITLE
Fix include header path to match upstream master

### DIFF
--- a/node.hpp
+++ b/node.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <wayfire/geometry.hpp>
-#include <wayfire/scene.hpp>
+#include <wayfire/scene-render.hpp>
 #include <wayfire/core.hpp>
 #include <wayfire/signal-definitions.hpp>
 #include <wayfire/toplevel-view.hpp>


### PR DESCRIPTION
Looks like upstream made a more specific header, so we need to use scene-render.hpp instead of just scene.hpp